### PR TITLE
Adding safety measure to launch ability of the dragonborn

### DIFF
--- a/data/better_origins/powers/dragonborn_launch.json
+++ b/data/better_origins/powers/dragonborn_launch.json
@@ -25,6 +25,10 @@
         "comparison": ">",
         "compare_to": 0.0,
         "inverted": true
+      },
+      {
+        "type": "origins:elytra_flight_possible",
+        "check_abilities": true
       }
     ]
   }


### PR DESCRIPTION
You cannot launch when you don't have elytra (i.e it starts to rain)